### PR TITLE
Fix - Module not found, can't resolve 'child_process' with next.js app

### DIFF
--- a/packages/smartwallet-utils/package-lock.json
+++ b/packages/smartwallet-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@argent/smartwallet-utils",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/smartwallet-utils/src/index.ts
+++ b/packages/smartwallet-utils/src/index.ts
@@ -2,17 +2,16 @@ import { ethers } from 'ethers'
 import { Wallet } from './interfaces'
 import { EOA } from './wallets/eoa'
 import { Argent } from './wallets/argent'
-import { AsyncSendable, Web3Provider } from 'ethers/providers/web3-provider'
 
 export class SmartWalletUtils {
 
-    provider: Web3Provider
+    provider: ethers.providers.Web3Provider
     wallets: Array<Wallet>
     address: string
 
-    constructor(ethereum: AsyncSendable, address: string) {
+    constructor(ethereum: ethers.providers.AsyncSendable, address: string) {
 
-        this.provider = new Web3Provider(ethereum)
+        this.provider = new ethers.providers.Web3Provider(ethereum)
         if (!ethers.utils.getAddress(address)) {
             throw new Error('Invalid address')
         }

--- a/packages/smartwallet-utils/src/interfaces.ts
+++ b/packages/smartwallet-utils/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Contract } from 'ethers/contract'
+import { ethers } from 'ethers'
 
 export enum WalletType {
     EOA,
@@ -8,7 +8,7 @@ export enum WalletType {
 export interface Wallet {
     type: WalletType
     address: string
-    contract?: Contract
+    contract?: ethers.Contract
     supportEIP1271: boolean
     supportApproveAndCall: boolean
     getName: () => string

--- a/packages/smartwallet-utils/src/wallets/argent.ts
+++ b/packages/smartwallet-utils/src/wallets/argent.ts
@@ -1,7 +1,5 @@
 import { Wallet, WalletType } from '../interfaces'
-import { utils } from 'ethers';
-import { Web3Provider } from 'ethers/providers/web3-provider'
-import { Contract } from 'ethers/contract'
+import { ethers, utils } from 'ethers'
 
 const argentABI = [
     'function isValidSignature(bytes32 _message, bytes _signature) public view returns (bool)',
@@ -12,14 +10,14 @@ const DEFAULT_GAS_APPROVECALL = 500000
 
 export class Argent implements Wallet {
 
-    provider: Web3Provider
-    contract: Contract
+    provider: ethers.providers.Web3Provider
+    contract: ethers.Contract
     type: WalletType
     address: string
     supportEIP1271: boolean
     supportApproveAndCall: boolean
 
-    constructor(address: string, provider: Web3Provider) {
+    constructor(address: string, provider: ethers.providers.Web3Provider) {
         this.type = WalletType.Argent
         this.provider = provider;
         this.supportEIP1271 = true
@@ -34,11 +32,11 @@ export class Argent implements Wallet {
         return 'Argent'
     }
 
-    async getWalletContract(): Promise<Contract> {
+    async getWalletContract(): Promise<ethers.Contract> {
         if (this.contract) return this.contract
 
         const signer = await this.provider.getSigner(0)
-        this.contract = new Contract(this.address, argentABI, signer)
+        this.contract = new ethers.Contract(this.address, argentABI, signer)
         return this.contract
     }
 


### PR DESCRIPTION
I've found an issue in the @argent/smartwallet-utils package. The issue is that our next.js app fails to compile after importing @argent/smartwallet-utils with this error:

```
[ error ] ./node_modules/xmlhttprequest/lib/XMLHttpRequest.js
Module not found: 
Can't resolve 'child_process' in 
'../pool-frontend/node_modules/xmlhttprequest/lib'
```
I've tracked it down to what I believe is this older issue with ethers where they suggest not importing from subpaths:

https://github.com/ethers-io/ethers.js/issues/349

After changing it to the code in this PR I've got it working against the pooltogether frontend. 👍 

That said, I imagine there is a better way to point to those types (ie. something better than using `ethers.providers.SendAsyncable` everywhere).
