### PR TITLE
Include type definitions when building the smartwallet-utils

### DIFF
--- a/packages/smartwallet-utils/package.json
+++ b/packages/smartwallet-utils/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.8",
   "description": "Utilities for smart-contract wallets",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && tsc",
     "test": "mocha -r ts-node/register test/**/*.spec.ts"

--- a/packages/smartwallet-utils/tsconfig.json
+++ b/packages/smartwallet-utils/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "sourceMap": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true
   },
   "include": [
       "src/**/*"


### PR DESCRIPTION
I noticed that the current version of `@argent/smartwallet-utils` does not include any type definitions, which can cause issues when using it in a typescript project. 